### PR TITLE
Modify list tag output to show tags per hour.

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -226,9 +226,9 @@ class Tagger {
             return utils.createEmbed(false, 'No tags found');
         }
         
-        const minutes = this.calculateMinutes(stream.streamStart, stream.streamEnd);
+        const duration = this.calculateDuration(stream.streamStart, stream.streamEnd, 'hours');
         let tagInfo = `Stream start: <t:${parseInt(stream.streamStart / 1000, 10)}:f>, `;
-        tagInfo += `${tagList.length} tags (${(tagList.length / minutes).toFixed(2)}/min)\n`;
+        tagInfo += `${tagList.length} tags (${(tagList.length / duration).toFixed(2)}/hr)\n`;
         if (stream.streamUrl) {
             tagInfo += `Link: ${stream.streamUrl}\n`;
         }
@@ -310,11 +310,21 @@ class Tagger {
         return text;
     }
 
-    calculateMinutes(streamStart, streamEnd) {
+    calculateDuration(streamStart, streamEnd, unit = 'minutes') {
         const start = streamStart;
         const end = streamEnd || new Date();
         const diffMs = end - start;
-        return Math.floor(diffMs / 60000);
+
+        switch(unit) {
+            case 'hours':
+                return diffMs / 3_600_000;
+
+            case 'minutes':
+                return Math.floor(diffMs / 60000);
+
+            default:
+                return diffMs;
+        }
     }
 
     calculateOffset(time, streamStart) {

--- a/tagger.js
+++ b/tagger.js
@@ -310,6 +310,7 @@ class Tagger {
         return text;
     }
 
+    calculateMinutes(streamStart, streamEnd) { return calculateDuration(streamStart, streamEnd, 'minutes'); }
     calculateDuration(streamStart, streamEnd, unit = 'minutes') {
         const start = streamStart;
         const end = streamEnd || new Date();

--- a/tagger.js
+++ b/tagger.js
@@ -226,9 +226,9 @@ class Tagger {
             return utils.createEmbed(false, 'No tags found');
         }
         
-        const duration = this.calculateDuration(stream.streamStart, stream.streamEnd, 'hours');
+        const hours = this.calculateHours(stream.streamStart, stream.streamEnd);
         let tagInfo = `Stream start: <t:${parseInt(stream.streamStart / 1000, 10)}:f>, `;
-        tagInfo += `${tagList.length} tags (${(tagList.length / duration).toFixed(2)}/hr)\n`;
+        tagInfo += `${tagList.length} tags (${(tagList.length / hours).toFixed(1)}/hr)\n`;
         if (stream.streamUrl) {
             tagInfo += `Link: ${stream.streamUrl}\n`;
         }
@@ -310,22 +310,11 @@ class Tagger {
         return text;
     }
 
-    calculateMinutes(streamStart, streamEnd) { return calculateDuration(streamStart, streamEnd, 'minutes'); }
-    calculateDuration(streamStart, streamEnd, unit = 'minutes') {
+    calculateHours(streamStart, streamEnd) {
         const start = streamStart;
         const end = streamEnd || new Date();
         const diffMs = end - start;
-
-        switch(unit) {
-            case 'hours':
-                return diffMs / 3_600_000;
-
-            case 'minutes':
-                return Math.floor(diffMs / 60000);
-
-            default:
-                return diffMs;
-        }
+        return Math.ceil(diffMs / (60 * 60 * 1000));
     }
 
     calculateOffset(time, streamStart) {


### PR DESCRIPTION
Tag frequency is arguably a vanity stat in general, but no one is tagging a stream often enough that minute granularity is a meaningful comparison.