### PR TITLE
Always print tags with offset time

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -328,8 +328,10 @@ class Tagger {
         const offset = this.calculateOffset(tag.time, streamStart);
         if (url) {
             text += ` [${offset}](${url}?t=${offset})\n`;
-        } else {
+        } else if (streamStart) {
             text += ` ${offset}\n`;
+        } else {
+            text += ` ${tag.time.getTime()}\n`;
         }
         return text;
     }

--- a/tagger.js
+++ b/tagger.js
@@ -325,11 +325,11 @@ class Tagger {
         if (tag.stars > 0) {
             text += ` (${tag.stars})`;
         }
+        const offset = this.calculateOffset(tag.time, streamStart);
         if (url) {
-            const offset = this.calculateOffset(tag.time, streamStart);
             text += ` [${offset}](${url}?t=${offset})\n`;
         } else {
-            text += ` ${tag.time.getTime()}\n`;
+            text += ` ${offset}\n`;
         }
         return text;
     }


### PR DESCRIPTION
When there's no vods, the printing tags prints the tags with unix timestamps. Since the stream start is always known, it's still possible to calculate and show the timestamp, even if there's no vod to link to.

This both helps taggers and people who have recorded the vod separately from twitch.